### PR TITLE
Added logging, uninstall option, and updated version 

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "getada"
 description = "The unofficial installer for Alire."
-version = "0.1.1-dev"
+version = "0.2.0-dev"
 licenses = "GPL-3.0-only"
 
 authors = ["A.J. Ianozi"]

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ Hopefully this can be solved in due time.
 ## How does it work?
 Once downloaded, simply run the application as-is, and it will prompt you to install Alire.  For instructions on how to use it, run `getada --help` or `getada -h`.
 
+If you want to undo everything that GetAda did, simply run `getada --uninstall`.
+
 It will download the latest version of Alire for your platform as a zip file to a metadata directory and then extract it to a binary directory.  By default the metadata directory is `~/.cache/getada`, the config directory is `~/.getada`, and the `alr` binary goes in `~/.getada/bin`.
 
 After extracting, it will then add the binary directory to your path, by creating a `env.sh` file (for sh/zsh/bash; other shells like `fish` are possible in the future) that adds the directory to $PATH if it doesn't already exist.  That file will be sourced in the shell's default env file (e.g. `.profile`).

--- a/src/console_io.adb
+++ b/src/console_io.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/console_io.adb
+++ b/src/console_io.adb
@@ -1,0 +1,46 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+with Ada.Text_IO; use Ada.Text_IO;
+package body Console_IO is
+   function Init (Our_Settings : Program_Settings) return C_IO is
+      Result : C_IO :=
+        (Quiet           => Our_Settings.Quiet,
+         Non_Interactive => Our_Settings.Non_Interactive);
+   begin
+      return Result;
+   end Init;
+   --  Posts a message, but only if messages aren't suppressed.
+   procedure Say_Line (This : C_IO; Item : String) is
+   begin
+      if not This.Quiet then
+         Put_Line (Item);
+      end if;
+   end Say_Line;
+   --  Like Say_Line but suppresses if quiet AND non-interactive.
+   procedure Must_Say (This : C_IO; Item : String) is
+   begin
+      if not (This.Quiet and then This.Non_Interactive) then
+         Put_Line (Item);
+      end if;
+   end Must_Say;
+
+   function Say (This : C_IO; Item : String) return String is
+   begin
+      return (if not This.Quiet then Item else "");
+   end Say;
+end Console_IO;

--- a/src/console_io.adb
+++ b/src/console_io.adb
@@ -18,7 +18,7 @@
 with Ada.Text_IO; use Ada.Text_IO;
 package body Console_IO is
    function Init (Our_Settings : Program_Settings) return C_IO is
-      Result : C_IO :=
+      Result : constant C_IO :=
         (Quiet           => Our_Settings.Quiet,
          Non_Interactive => Our_Settings.Non_Interactive);
    begin

--- a/src/console_io.ads
+++ b/src/console_io.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/console_io.ads
+++ b/src/console_io.ads
@@ -15,18 +15,18 @@
 --    You should have received a copy of the GNU General Public License
 --    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package Prompts is
-   type Answer is
-     (No, --  Answer is "No"
-      Yes, --  Answer is "Yes"
-      Other,  --  "other" - useful for providing 3rd option
-      DisableDefault);
+with Settings; use Settings;
 
-   function Get_Answer
-     (Prompt        : String; Default_Answer : Answer := DisableDefault;
-      Provided_Text : String := "") return Answer;
+package Console_IO is
+   type C_IO is tagged private;
+   function Init (Our_Settings : Program_Settings) return C_IO;
+   procedure Say_Line (This : C_IO; Item : String);
+   procedure Must_Say (This : C_IO; Item : String);
+   function Say (This : C_IO; Item : String) return String;
+private
+   type C_IO is tagged record
+      Quiet           : Boolean;
+      Non_Interactive : Boolean;
+   end record;
 
-   function Get_Answer
-     (Prompt        : String; Default_Answer : String := "";
-      Provided_Text : String := "") return String;
-end Prompts;
+end Console_IO;

--- a/src/console_io.ads
+++ b/src/console_io.ads
@@ -22,9 +22,13 @@ package Console_IO is
    --  Initiate the console IO
    function Init (Our_Settings : Program_Settings) return C_IO;
 
-   --  Prints the line if 
+   --  Prints the line if quiet is not enabled
    procedure Say_Line (This : C_IO; Item : String);
+
+   --  Returns string if quiet is not enabled
    function Say (This : C_IO; Item : String) return String;
+
+   --  Prints even if quiet is enabled
    procedure Must_Say (This : C_IO; Item : String);
 private
    type C_IO is tagged record

--- a/src/console_io.ads
+++ b/src/console_io.ads
@@ -19,10 +19,13 @@ with Settings; use Settings;
 
 package Console_IO is
    type C_IO is tagged private;
+   --  Initiate the console IO
    function Init (Our_Settings : Program_Settings) return C_IO;
+
+   --  Prints the line if 
    procedure Say_Line (This : C_IO; Item : String);
-   procedure Must_Say (This : C_IO; Item : String);
    function Say (This : C_IO; Item : String) return String;
+   procedure Must_Say (This : C_IO; Item : String);
 private
    type C_IO is tagged record
       Quiet           : Boolean;

--- a/src/defaults.ads
+++ b/src/defaults.ads
@@ -1,3 +1,20 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 with Ada.Characters.Latin_1;
 package Defaults is
    --  Directories, starting at $HOME

--- a/src/defaults.ads
+++ b/src/defaults.ads
@@ -1,0 +1,45 @@
+with Ada.Characters.Latin_1;
+package Defaults is
+   --  Directories
+   Tmp_Dir : constant String := "/.cache/getada";
+   Cfg_Dir : constant String := "/.getada";
+   Bin_Dir : constant String := "/bin";
+
+   --  Environmental Variables
+   Tmp_Env : constant String := "GETADA_TMP";
+   Cfg_Env : constant String := "GETADA_CFG";
+   Bin_Env : constant String := "GETADA_BIN";
+   Ver_Env : constant String := "GETADA_ALIRE_VERSION";
+
+   --  Alire binary file
+   Alire : constant String := "alr";
+
+   --  Messages
+   NL : constant String :=
+     Ada.Characters.Latin_1.CR & Ada.Characters.Latin_1.LF;
+
+   Welcome_Message : constant String :=
+     "Welcome to the unofficial Alire Installer (""GetAda"")!" & NL &
+     "Alire is the official Ada Package Manager. For more information" & NL &
+     "please visit https://ada-lang.io or https://alire.ada.dev" & NL &
+     "Copyright (C) 2022 A.J. Ianozi licensed GPL3.";
+
+   Help_Message : constant String :=
+     "Options: " & NL & "-h --help: Print this message and exit." & NL &
+     "-p --no-path: Don't update path." & NL &
+     "-n --non-interactive: Suppress prompts; answer with defaults." & NL &
+     "-q --quiet: Be quiet (does not suppress propmts)" & NL &
+     "-m /directory --tmp=/directory: Set tmp/metadata " & NL &
+     "-c /directory --cfg=/directory: Set config directory " & NL &
+     "-b /directory --bin=/directory: Set binary directory " & NL &
+     "-v x.y.z --version=x.y.z: Download a specific version." & NL &
+     "-u --uninstall: Uninstall Alire. This only works if Alire was" & NL &
+     "                installed in a default directory or --cfg is passed." &
+     NL & "You can also set the version and metadata / binary directory by " &
+     NL & "setting the following environment variables:" & NL & " * """ &
+     Ver_Env & """  for Alire's version" & NL & " * """ & Tmp_Env &
+     """ for metadata directory" & NL & " * """ & Cfg_Env &
+     """ for config directory" & NL & " * """ & Bin_Env &
+     """ for binary directory" & NL & "That's it for right now!";
+
+end Defaults;

--- a/src/defaults.ads
+++ b/src/defaults.ads
@@ -1,15 +1,16 @@
 with Ada.Characters.Latin_1;
 package Defaults is
-   --  Directories
-   Tmp_Dir : constant String := "/.cache/getada";
-   Cfg_Dir : constant String := "/.getada";
-   Bin_Dir : constant String := "/bin";
+   --  Directories, starting at $HOME
+   Tmp_Dir : constant String := "/.cache/getada"; --  Temporary files to remove
+   Cfg_Dir : constant String := "/.getada";       --  Config, scripts, bin, etc
+   Bin_Dir : constant String := "/bin";           --  Located in Cfg_Dir
+   Log_File : constant String := "/log.dat";       --  Located in Cfg_Dir
 
    --  Environmental Variables
-   Tmp_Env : constant String := "GETADA_TMP";
-   Cfg_Env : constant String := "GETADA_CFG";
-   Bin_Env : constant String := "GETADA_BIN";
-   Ver_Env : constant String := "GETADA_ALIRE_VERSION";
+   Tmp_Env : constant String := "GETADA_TMP";           --  Override Tmp_Dir
+   Cfg_Env : constant String := "GETADA_CFG";           --  Override Cfg_Dir
+   Bin_Env : constant String := "GETADA_BIN";           --  Override Bin_Dir
+   Ver_Env : constant String := "GETADA_ALIRE_VERSION"; --  Override latest ver
 
    --  Alire binary file
    Alire : constant String := "alr";
@@ -25,11 +26,12 @@ package Defaults is
      "Copyright (C) 2022 A.J. Ianozi licensed GPL3.";
 
    Help_Message : constant String :=
-     "Options: " & NL & "-h --help: Print this message and exit." & NL &
+     "Options: " & NL &
+     "-h --help: Print this message and exit." & NL &
      "-p --no-path: Don't update path." & NL &
      "-n --non-interactive: Suppress prompts; answer with defaults." & NL &
      "-q --quiet: Be quiet (does not suppress propmts)" & NL &
-     "-m /directory --tmp=/directory: Set tmp/metadata " & NL &
+     "-t /directory --tmp=/directory: Set tmp/metadata " & NL &
      "-c /directory --cfg=/directory: Set config directory " & NL &
      "-b /directory --bin=/directory: Set binary directory " & NL &
      "-v x.y.z --version=x.y.z: Download a specific version." & NL &

--- a/src/defaults.ads
+++ b/src/defaults.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --
@@ -17,6 +17,9 @@
 
 with Ada.Characters.Latin_1;
 package Defaults is
+   --  About GetAda
+   Getada_Version : constant String := "0.2.0-dev"; --  Must match alire.toml
+
    --  Directories, starting at $HOME
    Tmp_Dir  : constant String := "/.cache/getada"; --  Temporary files
    Cfg_Dir  : constant String := "/.getada";       --  Config, scripts, bin
@@ -37,20 +40,22 @@ package Defaults is
      Ada.Characters.Latin_1.CR & Ada.Characters.Latin_1.LF;
 
    Welcome_Message : constant String :=
-     "Welcome to the unofficial Alire Installer (""GetAda"")!" & NL &
+     "Welcome to the unofficial Alire Installer (""GetAda"") v" &
+     Getada_Version & "!" & NL &
      "Alire is the official Ada Package Manager. For more information" & NL &
      "please visit https://ada-lang.io or https://alire.ada.dev" & NL &
-     "Copyright (C) 2022 A.J. Ianozi licensed GPL3.";
+     "Copyright (C) 2022-2023 A.J. Ianozi licensed GPL3.";
 
    Help_Message : constant String :=
      "Options: " & NL & "-h --help: Print this message and exit." & NL &
+     "-s --show-version: Print the version of this binary and exit." & NL &
      "-p --no-path: Don't update path." & NL &
      "-n --non-interactive: Suppress prompts; answer with defaults." & NL &
      "-q --quiet: Be quiet (does not suppress propmts)" & NL &
      "-t /directory --tmp=/directory: Set tmp/metadata " & NL &
      "-c /directory --cfg=/directory: Set config directory " & NL &
      "-b /directory --bin=/directory: Set binary directory " & NL &
-     "-v x.y.z --version=x.y.z: Download a specific version." & NL &
+     "-v x.y.z --version=x.y.z: Download a specific version of alire." & NL &
      "-u --uninstall: Uninstall Alire. This only works if Alire was" & NL &
      "                installed with GetAda.  Works out of the box if" & NL &
      "                default directory was used, otherwise you must" & NL &

--- a/src/defaults.ads
+++ b/src/defaults.ads
@@ -1,9 +1,9 @@
 with Ada.Characters.Latin_1;
 package Defaults is
    --  Directories, starting at $HOME
-   Tmp_Dir : constant String := "/.cache/getada"; --  Temporary files to remove
-   Cfg_Dir : constant String := "/.getada";       --  Config, scripts, bin, etc
-   Bin_Dir : constant String := "/bin";           --  Located in Cfg_Dir
+   Tmp_Dir  : constant String := "/.cache/getada"; --  Temporary files
+   Cfg_Dir  : constant String := "/.getada";       --  Config, scripts, bin
+   Bin_Dir  : constant String := "/bin";           --  Located in Cfg_Dir
    Log_File : constant String := "/log.dat";       --  Located in Cfg_Dir
 
    --  Environmental Variables
@@ -26,8 +26,7 @@ package Defaults is
      "Copyright (C) 2022 A.J. Ianozi licensed GPL3.";
 
    Help_Message : constant String :=
-     "Options: " & NL &
-     "-h --help: Print this message and exit." & NL &
+     "Options: " & NL & "-h --help: Print this message and exit." & NL &
      "-p --no-path: Don't update path." & NL &
      "-n --non-interactive: Suppress prompts; answer with defaults." & NL &
      "-q --quiet: Be quiet (does not suppress propmts)" & NL &
@@ -36,10 +35,12 @@ package Defaults is
      "-b /directory --bin=/directory: Set binary directory " & NL &
      "-v x.y.z --version=x.y.z: Download a specific version." & NL &
      "-u --uninstall: Uninstall Alire. This only works if Alire was" & NL &
-     "                installed in a default directory or --cfg is passed." &
-     NL & "You can also set the version and metadata / binary directory by " &
-     NL & "setting the following environment variables:" & NL & " * """ &
-     Ver_Env & """  for Alire's version" & NL & " * """ & Tmp_Env &
+     "                installed with GetAda.  Works out of the box if" & NL &
+     "                default directory was used, otherwise you must" & NL &
+     "                pass --cfg= so the uninstaller can find the log." & NL &
+     "You can also set the version and tmp/cfg/binary directories by " & NL &
+     "setting the following environment variables:" & NL & " * """ & Ver_Env &
+     """  for Alire's version" & NL & " * """ & Tmp_Env &
      """ for metadata directory" & NL & " * """ & Cfg_Env &
      """ for config directory" & NL & " * """ & Bin_Env &
      """ for binary directory" & NL & "That's it for right now!";

--- a/src/files.adb
+++ b/src/files.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/files.adb
+++ b/src/files.adb
@@ -1,0 +1,46 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+with Ada.Directories;   use Ada.Directories;
+with Ada.Text_IO;       use Ada.Text_IO;
+with Ada.Strings.Fixed; use Ada.Strings.Fixed;
+package body Files is
+
+   function Line_Exists (Full_Path : String; Line : String) return Boolean is
+      File_To_Check : File_Type;
+      Result        : Boolean := False;
+   begin
+      if Ada.Directories.Exists (Full_Path) then
+         Open (File_To_Check, In_File, Full_Path);
+         --  Iterate through the file, looking for a PATH export.
+         Check_File :
+         while not End_Of_File (File_To_Check) loop
+            declare
+               Next_Line : constant String := Get_Line (File_To_Check);
+            begin
+               if Index (Next_Line, Line) > 0 then
+                  --  Contains our env file
+                  Result := True;
+                  exit Check_File;
+               end if;
+            end;
+         end loop Check_File;
+         Close (File_To_Check);
+      end if;
+      return Result;
+   end Line_Exists;
+end Files;

--- a/src/files.adb
+++ b/src/files.adb
@@ -24,7 +24,7 @@ package body Files is
       File_To_Check : File_Type;
       Result        : Boolean := False;
    begin
-      if Ada.Directories.Exists (Full_Path) then
+      if Exists (Full_Path) then
          Open (File_To_Check, In_File, Full_Path);
          --  Iterate through the file, looking for a PATH export.
          Check_File :

--- a/src/files.ads
+++ b/src/files.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/files.ads
+++ b/src/files.ads
@@ -15,18 +15,8 @@
 --    You should have received a copy of the GNU General Public License
 --    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package Prompts is
-   type Answer is
-     (No, --  Answer is "No"
-      Yes, --  Answer is "Yes"
-      Other,  --  "other" - useful for providing 3rd option
-      DisableDefault);
-
-   function Get_Answer
-     (Prompt        : String; Default_Answer : Answer := DisableDefault;
-      Provided_Text : String := "") return Answer;
-
-   function Get_Answer
-     (Prompt        : String; Default_Answer : String := "";
-      Provided_Text : String := "") return String;
-end Prompts;
+package Files is
+   --  Returns if a line exists in a given file.  If the file doesn't exist,
+   --  it will return False.
+   function Line_Exists (Full_Path : String; Line : String) return Boolean;
+end Files;

--- a/src/getada.adb
+++ b/src/getada.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --
@@ -38,20 +38,22 @@ begin
    if Options.Show_Help then
       --  Just show the help message and exit. -q won't count.
       Put_Line (Defaults.Help_Message);
-      return;
+   elsif Options.Show_Version Then
+      --  Just show the version and exit.  -q won't count.
+      Put_Line(Defaults.Getada_Version);
+   else
+      declare
+         Settings : constant Program_Settings := Init_Settings (Options);
+      begin
+         if Options.Uninstall then
+            --  Start our uninstaller.
+            Uninstall (Settings);
+         else
+            --  Start our installer.
+            Install (Settings);
+         end if;
+      end;
    end if;
-
-   declare
-      Settings : constant Program_Settings := Init_Settings (Options);
-   begin
-      if Options.Uninstall then
-         --  Start our uninstaller.
-         Uninstall (Settings);
-      else
-         --  Start our installer.
-         Install (Settings);
-      end if;
-   end;
 exception
    when Installer.User_Aborted =>
       Put_Line ("Aborted... Closing program.");

--- a/src/getada.adb
+++ b/src/getada.adb
@@ -16,59 +16,41 @@
 --    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 pragma Assertion_Policy (Check);
-with Installer; use Installer;
-with Options;   use Options;
+with Defaults;
+with Installer;   use Installer;
+with Options;     use Options;
+with Settings;    use Settings;
 with Ada.Text_IO; use Ada.Text_IO;
-
-with Ada.Characters.Latin_1; use Ada.Characters.Latin_1;
 
 procedure Getada is
 
-   procedure Show_Welcome is
-      Welcome_Message : constant String :=
-        "Welcome to the unofficial Alire Installer (""GetAda"")!" & CR & LF &
-        "Alire is the official Ada Package Manager. For more information" &
-        CR & LF & "please visit https://ada-lang.io or https://alire.ada.dev" &
-        CR & LF & "Copyright (C) 2022 A.J. Ianozi licensed GPL3.";
-   begin
-      Put_Line (Welcome_Message);
-   end Show_Welcome;
-
-   procedure Show_Help is
-      Help_Message : constant String :=
-        "Options: " & CR & LF & "-h --help: Print this message and exit." &
-        CR & LF & "-p --no-path: Don't update path." & CR & LF &
-        "-m /directory --meta=/directory: Set tmp/metadata " & CR &
-        LF & "-c /directory --cfg=/directory: Set config directory " & CR &
-        LF & "-b /directory --bin=/directory: Set binary directory " & CR &
-        LF & "-v x.y.z --version=x.y.z: Download a specific version." & CR &
-        LF &
-        "You can also set the version and metadata / binary directory by " &
-        "setting the following environment variables:" & CR & LF &
-        " * """ & Defaults.Ver_Env & """  for Alire's version" & CR & LF &
-        " * """ & Defaults.Tmp_Env & """ for metadata directory" & CR & LF &
-        " * """ & Defaults.Cfg_Env & """ for config directory" & CR & LF &
-        " * """ & Defaults.Bin_Env & """ for binary directory" & CR & LF &
-        "That's it for right now!";
-   begin
-      Put_Line (Help_Message);
-   end Show_Help;
-
    --  This will hold our options for running this program.
    Options : constant Program_Options := Process_Arguments;
+
 begin
 
    --  Welcome the user to our program :)
-   Show_Welcome;
+   if not Options.Quiet then
+      Put_Line (Defaults.Welcome_Message);
+   end if;
 
    if Options.Show_Help then
-      --  Just show the help message and exit.
-      Show_Help;
+      --  Just show the help message and exit. -q won't count.
+      Put_Line (Defaults.Help_Message);
       return;
-   else
-
-      --  Start our installer.
-      Install (Options);
    end if;
+
+   declare
+      Settings : constant Program_Settings := Init_Settings (Options);
+   begin
+      if Options.Uninstall then
+         --  Start our uninstaller.
+         --  Uninstall (Settings);
+         null;
+      else
+         --  Start our installer.
+         Install (Settings);
+      end if;
+   end;
 
 end Getada;

--- a/src/getada.adb
+++ b/src/getada.adb
@@ -18,6 +18,7 @@
 pragma Assertion_Policy (Check);
 with Defaults;
 with Installer;   use Installer;
+with Uninstaller; use Uninstaller;
 with Options;     use Options;
 with Settings;    use Settings;
 with Ada.Text_IO; use Ada.Text_IO;
@@ -45,12 +46,13 @@ begin
    begin
       if Options.Uninstall then
          --  Start our uninstaller.
-         --  Uninstall (Settings);
-         null;
+         Uninstall (Settings);
       else
          --  Start our installer.
          Install (Settings);
       end if;
    end;
-
+exception
+   when Installer.User_Aborted =>
+      Put_Line ("Aborted... Closing program.");
 end Getada;

--- a/src/installer.adb
+++ b/src/installer.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/installer.adb
+++ b/src/installer.adb
@@ -197,8 +197,10 @@ package body Installer is
             IO.Must_Say (Home_Dir & "/" & To_String (Shell.Config_File));
          end loop;
 
-         IO.Must_Say
-           (IO.Say (NL & "(This can be changed by passing --no-path)"));
+         IO.Must_Say ("(This can be changed by passing --no-path)" & NL);
+
+         IO.Must_Say ("You can revert everything that was done by re-running" &
+                      " GetAda with the --uninstall option." & NL);
 
       end if;
       --  Ask user if they want to install the propgram, or offer interactive

--- a/src/installer.adb
+++ b/src/installer.adb
@@ -485,7 +485,6 @@ package body Installer is
                  Cfg_Dir & "/" & Get_Shell_Env (Config.Shell);
                Command : constant String :=
                  Get_Env_Command (Config.Shell, Env_Path);
-               No_Source_In_Env : Boolean := True;
             begin
                --  If the env for this shell does not exist
                if not Ada.Directories.Exists (Env_Path) then

--- a/src/installer.ads
+++ b/src/installer.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --
@@ -24,7 +24,7 @@ package Installer is
 
    Invalid_Version, Invalid_Download, Invalid_File, No_Environment_Variable,
    OS_Not_Yet_Supported, User_Aborted : exception;
-
+   
    --  Just to verify we're using theh correct version format.
    subtype Valid_Version is Character with
         Static_Predicate => Valid_Version in 'A' .. 'Z' | 'a' .. 'z' |

--- a/src/installer.ads
+++ b/src/installer.ads
@@ -24,7 +24,7 @@ package Installer is
 
    Invalid_Version, Invalid_Download, Invalid_File, No_Environment_Variable,
    OS_Not_Yet_Supported, User_Aborted : exception;
-   
+
    --  Just to verify we're using theh correct version format.
    subtype Valid_Version is Character with
         Static_Predicate => Valid_Version in 'A' .. 'Z' | 'a' .. 'z' |

--- a/src/installer.ads
+++ b/src/installer.ads
@@ -18,7 +18,6 @@
 pragma Assertion_Policy (Check);
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Directories;
-with Options;               use Options;
 with Settings;              use Settings;
 with Defaults;
 package Installer is

--- a/src/installer.ads
+++ b/src/installer.ads
@@ -19,50 +19,32 @@ pragma Assertion_Policy (Check);
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Directories;
 with Options;               use Options;
+with Settings;              use Settings;
+with Defaults;
 package Installer is
-   package Defaults is
-      --  Directories
-      Tmp_Dir : constant String := "/.cache/getada";
-      Cfg_Dir : constant String := "/.getada";
-      Bin_Dir : constant String := "/bin";
-
-      --  Environmental Variables
-      Tmp_Env : constant String := "GETADA_TMP";
-      Cfg_Env : constant String := "GETADA_CFG";
-      Bin_Env : constant String := "GETADA_BIN";
-      Ver_Env : constant String := "GETADA_ALIRE_VERSION";
-
-   end Defaults;
-
-   --  The binary for Alire.
-   Alire : constant String := "alr";
 
    Invalid_Version, Invalid_Download, Invalid_File, No_Environment_Variable,
    OS_Not_Yet_Supported, User_Aborted : exception;
-   type Yes_or_No is (No, Yes, NA);
+
    --  Just to verify we're using theh correct version format.
    subtype Valid_Version is Character with
         Static_Predicate => Valid_Version in 'A' .. 'Z' | 'a' .. 'z' |
             '0' .. '9' | '-' | '.';
 
-   procedure Install (Options : Program_Options) with
+   procedure Install (Our_Settings : Program_Settings) with
       Pre =>
-      (for all I in 1 .. Length (Options.Version) =>
-         Element (Options.Version, I) in Valid_Version
+      (for all I in 1 .. Length (Our_Settings.Version) =>
+         Element (Our_Settings.Version, I) in Valid_Version
          or else raise Invalid_Version
-           with "ERROR: Invalid version: " & To_String (Options.Version));
+           with "ERROR: Invalid version: " & To_String (Our_Settings.Version));
 private
-   function Correct_Path (Home_Dir : String; Path : String) return String;
-   function Get_Answer
-     (Prompt : String; Default_Answer : Yes_or_No := NA) return Yes_or_No;
-   function Get_Answer
-     (Prompt : String; Default_Answer : String := "") return String;
    --  Will add this back in when we have AWS
    --  procedure Download (URL : String; Destination_File : String);
    procedure Download (URL : String);
    procedure Extract_Alire (File : String) with
       Pre => Ada.Directories.Exists (File)
       or else raise Invalid_File with "Unable to load file: " & File,
-      Post => Ada.Directories.Exists ("alr")
-      or else raise Invalid_File with "Unable to find ""alr"" in: " & File;
+      Post => Ada.Directories.Exists (Defaults.Alire)
+      or else raise Invalid_File
+        with "Unable to find """ & Defaults.Alire & """ in: " & File;
 end Installer;

--- a/src/logger.adb
+++ b/src/logger.adb
@@ -1,12 +1,48 @@
+with Ada.Streams.Stream_IO; use Ada.Streams.Stream_IO;
+
 package body Logger is
-
-
-   procedure Create_Log(File_Name : String; Log : Install_Log_Entry);
-
-   function Read_Log(File_Name: String) return Install_Log_Entry is
-      Log : Install_Log_Entry;
+   function Init (Our_Settings : Program_Settings) return Install_Log_Entry is
+      Result : constant Install_Log_Entry :=
+        (Current_Settings => Our_Settings,
+         Recent_Stage => No_Stage,
+         Steps => (others => (Status => NA, Data => Null_Unbounded_String)));
    begin
-      
-   end;
+      return Result;
+   end Init;
+
+   procedure Logit
+     (Log            : in out Install_Log_Entry;
+      Current_Stage  :        Stage;
+      Current_Status :        Statuses;
+      Current_Data   :        String   := "")
+   is
+   begin
+      Log.Recent_Stage                 := Current_Stage;
+      Log.Steps (Current_Stage).Status := Current_Status;
+      Append (Log.Steps (Current_Stage).Data, Current_Data & Entry_Seperator);
+   end Logit;
+
+   procedure Save (Log       : Install_Log_Entry;
+                   File_Name : String)
+   is
+      Log_File   : File_Type;
+      Stream_Ptr : Stream_Access;
+   begin
+      Create (Log_File, Out_File, File_Name);
+      Stream_Ptr := Stream (Log_File);
+      Install_Log_Entry'Write (Stream_Ptr, Log);
+      Close (Log_File);
+   end Save;
+
+   function Load (File_Name : String) return Install_Log_Entry is
+      Log_File   : File_Type;
+      Stream_Ptr : Stream_Access;
+      Log        : Install_Log_Entry;
+   begin
+      Open (Log_File, In_File, File_Name);
+      Stream_Ptr := Stream (Log_File);
+      Install_Log_Entry'Read (Stream_Ptr, Log);
+      return Log;
+   end Load;
 
 end Logger;

--- a/src/logger.adb
+++ b/src/logger.adb
@@ -1,0 +1,12 @@
+package body Logger is
+
+
+   procedure Create_Log(File_Name : String; Log : Install_Log_Entry);
+
+   function Read_Log(File_Name: String) return Install_Log_Entry is
+      Log : Install_Log_Entry;
+   begin
+      
+   end;
+
+end Logger;

--- a/src/logger.adb
+++ b/src/logger.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/logger.adb
+++ b/src/logger.adb
@@ -16,7 +16,6 @@
 --    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 with Ada.Streams.Stream_IO; use Ada.Streams.Stream_IO;
-with Ada.Text_IO;
 package body Logger is
    function Init (Our_Settings : Program_Settings) return Install_Log is
       Result : constant Install_Log :=
@@ -102,15 +101,15 @@ package body Logger is
    begin
       Open (Log_File, In_File, File_Name);
       Stream_Ptr := Stream (Log_File);
-      -- First read in the current settings
+      --  First read in the current settings
       Program_Settings'Read (Stream_Ptr, Log.Current_Settings);
       --  Next, read the recent stage.
       Unbounded_String'Read (Stream_Ptr, Cur_Stage);
       --  And set it.
       Log.Recent_Stage := Stage'Value (To_String (Cur_Stage));
-      -- Next, the array size
+      --  Next, the array size
       Natural'Read (Stream_Ptr, Cur_Array_Size);
-      -- And load it in.
+      --  And load it in.
       declare
          Tmp_Stage : Stage;
       begin

--- a/src/logger.adb
+++ b/src/logger.adb
@@ -1,20 +1,34 @@
-with Ada.Streams.Stream_IO; use Ada.Streams.Stream_IO;
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+with Ada.Streams.Stream_IO; use Ada.Streams.Stream_IO;
+with Ada.Text_IO;
 package body Logger is
-   function Init (Our_Settings : Program_Settings) return Install_Log_Entry is
-      Result : constant Install_Log_Entry :=
-        (Current_Settings => Our_Settings,
-         Recent_Stage => No_Stage,
+   function Init (Our_Settings : Program_Settings) return Install_Log is
+      Result : constant Install_Log :=
+        (Current_Settings => Our_Settings, Recent_Stage => No_Stage,
          Steps => (others => (Status => NA, Data => Null_Unbounded_String)));
    begin
       return Result;
    end Init;
 
    procedure Logit
-     (Log            : in out Install_Log_Entry;
-      Current_Stage  :        Stage;
-      Current_Status :        Statuses;
-      Current_Data   :        String   := "")
+     (Log            : in out Install_Log; Current_Stage : Stage;
+      Current_Status :        Statuses; Current_Data : String := "")
    is
    begin
       Log.Recent_Stage                 := Current_Stage;
@@ -22,26 +36,94 @@ package body Logger is
       Append (Log.Steps (Current_Stage).Data, Current_Data & Entry_Seperator);
    end Logit;
 
-   procedure Save (Log       : Install_Log_Entry;
-                   File_Name : String)
-   is
+   function Get_Recent_Stage (Log : Install_Log) return Stage is
+   begin
+      return Log.Recent_Stage;
+   end Get_Recent_Stage;
+
+   function Get_Status (Log : Install_Log; Of_Stage : Stage) return Statuses is
+   begin
+      return Log.Steps (Of_Stage).Status;
+   end Get_Status;
+
+   function Get_Data (Log : Install_Log; Of_Stage : Stage) return String is
+      Data : constant String := To_String (Log.Steps (Of_Stage).Data);
+   begin
+      --  The data ends with "@" since tha's used as a seperator.
+      --  So remove the trailing "@" to make things easier later.
+      if Data = "@" or else Data'Length = 0 then
+         return "";
+      elsif Data (Data'Last) = '@' then
+         return Data (Data'First .. Data'Last - 1);
+      else
+         return Data;
+      end if;
+   end Get_Data;
+
+   function Get_Settings (Log : Install_Log) return Program_Settings is
+   begin
+      return Log.Current_Settings;
+   end Get_Settings;
+
+   procedure Save (Log : Install_Log; File_Name : String) is
       Log_File   : File_Type;
       Stream_Ptr : Stream_Access;
    begin
       Create (Log_File, Out_File, File_Name);
       Stream_Ptr := Stream (Log_File);
-      Install_Log_Entry'Write (Stream_Ptr, Log);
+      --  First write out the current settings
+      Program_Settings'Write (Stream_Ptr, Log.Current_Settings);
+      --  Next, write the recent stage as an unbounded string.
+      Unbounded_String'Write
+        (Stream_Ptr, To_Unbounded_String (Log.Recent_Stage'Image));
+      --  Then, write out the size of the array.
+      Natural'Write (Stream_Ptr, Log.Steps'Length);
+      --  Finally, write out each array step.
+      for I in Log.Steps'Range loop
+         --  Specify which step this is
+         Unbounded_String'Write (Stream_Ptr, To_Unbounded_String (I'Image));
+         --  Write out said step
+         Step'Write (Stream_Ptr, Log.Steps (I));
+      end loop;
       Close (Log_File);
    end Save;
 
-   function Load (File_Name : String) return Install_Log_Entry is
+   function Load (File_Name : String) return Install_Log is
       Log_File   : File_Type;
       Stream_Ptr : Stream_Access;
-      Log        : Install_Log_Entry;
+
+      --  Temporary variables to know what we're reading.
+      Cur_Stage      : Unbounded_String;
+      Cur_Array_Size : Natural;
+
+      --  Our result.
+      Log : Install_Log;
+
    begin
       Open (Log_File, In_File, File_Name);
       Stream_Ptr := Stream (Log_File);
-      Install_Log_Entry'Read (Stream_Ptr, Log);
+      -- First read in the current settings
+      Program_Settings'Read (Stream_Ptr, Log.Current_Settings);
+      --  Next, read the recent stage.
+      Unbounded_String'Read (Stream_Ptr, Cur_Stage);
+      --  And set it.
+      Log.Recent_Stage := Stage'Value (To_String (Cur_Stage));
+      -- Next, the array size
+      Natural'Read (Stream_Ptr, Cur_Array_Size);
+      -- And load it in.
+      declare
+         Tmp_Stage : Stage;
+      begin
+         for I in 1 .. Cur_Array_Size loop
+            --  Find out which step this is
+            Unbounded_String'Read (Stream_Ptr, Cur_Stage);
+            Tmp_Stage := Stage'Value (To_String (Cur_Stage));
+            --  Read in the step
+            Step'Read (Stream_Ptr, Log.Steps (Tmp_Stage));
+         end loop;
+      end;
+      Close (Log_File);
+
       return Log;
    end Load;
 

--- a/src/logger.ads
+++ b/src/logger.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/logger.ads
+++ b/src/logger.ads
@@ -1,21 +1,65 @@
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
-with Ada.Streams.Stream_IO;
 with Ada.Directories;
+
+with Settings; use Settings;
 
 package Logger is
 
    Invalid_File : exception;
-   type Install_Log_Entry is record
-      Version, Cfg_Dir, Bin_Dir : Unbounded_String := Null_Unbounded_String;
-   end record;
+   --  Entries in data log are separated by @, e.g. "Entry1@Entry2@Entry3"
+   Entry_Seperator : constant String := "@";
+   --  If more than one item per entry, e.g. "Entry1@Entry2A%Entry2B@Entry3"
+   Item_Seperator : constant String := "%";
+   --  This holds the stages of our installer, in order of process.
+   type Stage is
+     (No_Stage,
+      Created_Metadata,
+      Downloaded,
+      Created_Cfg,
+      Created_Bin,
+      Extracted,
+      Alr_Tested,
+      Created_Env_File,
+      Added_Env_File);
+   --  The status of each step
+   type Statuses is (Failed, Success, NA);
 
-   procedure Create_Log (File_Name : String; Log : Install_Log_Entry) with
-      --  Pre => not Ada.Directories.Exists (File_Name)
-      --  or else raise Invalid_File with "File exists: " & File_Name,
+   --  The logger structure itself.
+   type Install_Log_Entry is tagged private;
+
+   function Init
+     (Our_Settings : Program_Settings)
+      return Install_Log_Entry;
+
+   function Load (File_Name : String) return Install_Log_Entry with
+      Pre => Ada.Directories.Exists (File_Name)
+      or else raise Invalid_File with "File not found: " & File_Name;
+
+   procedure Save (Log       : Install_Log_Entry;
+                   File_Name : String) with
       Post => Ada.Directories.Exists (File_Name)
       or else raise Invalid_File with "Unable to create file " & File_Name;
 
-   function Read_Log (File_Name : String) return Install_Log_Entry with
-      Pre => Ada.Directories.Exists (File_Name)
-      or else raise Invalid_File with "File not found: " & File_Name;
+   --  Logs the data in the actual log structure
+   procedure Logit
+     (Log            : in out Install_Log_Entry;
+      Current_Stage  :        Stage;
+      Current_Status :        Statuses;
+      Current_Data   :        String   := "");
+private
+
+   --  The individual step.
+   type Step is record
+      Status : Statuses         := NA;
+      Data   : Unbounded_String := Null_Unbounded_String;
+   end record;
+   type Step_Array is array (Stage'Range) of Step;
+
+   --  The logger structure itself.
+   type Install_Log_Entry is tagged record
+      Current_Settings : Program_Settings; --  Settings used to install
+      Recent_Stage     : Stage;            --  The furthest stage it got to
+      Steps            : Step_Array;       --  Each step of process
+   end record;
+
 end Logger;

--- a/src/logger.ads
+++ b/src/logger.ads
@@ -1,3 +1,21 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma Assertion_Policy (Check);
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Directories;
 
@@ -25,27 +43,33 @@ package Logger is
    type Statuses is (Failed, Success, NA);
 
    --  The logger structure itself.
-   type Install_Log_Entry is tagged private;
+   type Install_Log is tagged private;
 
-   function Init
-     (Our_Settings : Program_Settings)
-      return Install_Log_Entry;
+   function Init (Our_Settings : Program_Settings) return Install_Log;
 
-   function Load (File_Name : String) return Install_Log_Entry with
+   function Load (File_Name : String) return Install_Log with
       Pre => Ada.Directories.Exists (File_Name)
       or else raise Invalid_File with "File not found: " & File_Name;
 
-   procedure Save (Log       : Install_Log_Entry;
-                   File_Name : String) with
+   procedure Save (Log : Install_Log; File_Name : String) with
       Post => Ada.Directories.Exists (File_Name)
       or else raise Invalid_File with "Unable to create file " & File_Name;
 
-   --  Logs the data in the actual log structure
+      --  Logs the data in the actual log structure
    procedure Logit
-     (Log            : in out Install_Log_Entry;
-      Current_Stage  :        Stage;
-      Current_Status :        Statuses;
-      Current_Data   :        String   := "");
+     (Log            : in out Install_Log; Current_Stage : Stage;
+      Current_Status :        Statuses; Current_Data : String := "");
+
+   --  Retrives the latest stage this log got to.
+   function Get_Recent_Stage (Log : Install_Log) return Stage;
+
+   --  Retrives the status of a log entry of x stage.
+   function Get_Status (Log : Install_Log; Of_Stage : Stage) return Statuses;
+
+   --  Retrives the data.
+   function Get_Data (Log : Install_Log; Of_Stage : Stage) return String;
+
+   function Get_Settings (Log : Install_Log) return Program_Settings;
 private
 
    --  The individual step.
@@ -56,7 +80,7 @@ private
    type Step_Array is array (Stage'Range) of Step;
 
    --  The logger structure itself.
-   type Install_Log_Entry is tagged record
+   type Install_Log is tagged record
       Current_Settings : Program_Settings; --  Settings used to install
       Recent_Stage     : Stage;            --  The furthest stage it got to
       Steps            : Step_Array;       --  Each step of process

--- a/src/logger.ads
+++ b/src/logger.ads
@@ -45,17 +45,20 @@ package Logger is
    --  The logger structure itself.
    type Install_Log is tagged private;
 
+   --  Initiates the logger structure.
    function Init (Our_Settings : Program_Settings) return Install_Log;
 
+   --  Loads the logger from a file
    function Load (File_Name : String) return Install_Log with
       Pre => Ada.Directories.Exists (File_Name)
       or else raise Invalid_File with "File not found: " & File_Name;
 
+   --  Saves the logger to a file
    procedure Save (Log : Install_Log; File_Name : String) with
       Post => Ada.Directories.Exists (File_Name)
       or else raise Invalid_File with "Unable to create file " & File_Name;
 
-      --  Logs the data in the actual log structure
+   --  Logs the data in the actual log structure
    procedure Logit
      (Log            : in out Install_Log; Current_Stage : Stage;
       Current_Status :        Statuses; Current_Data : String := "");
@@ -69,6 +72,7 @@ package Logger is
    --  Retrives the data.
    function Get_Data (Log : Install_Log; Of_Stage : Stage) return String;
 
+   --  Retrives the settings from the log
    function Get_Settings (Log : Install_Log) return Program_Settings;
 private
 

--- a/src/logger.ads
+++ b/src/logger.ads
@@ -1,0 +1,21 @@
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Ada.Streams.Stream_IO;
+with Ada.Directories;
+
+package Logger is
+
+   Invalid_File : exception;
+   type Install_Log_Entry is record
+      Version, Cfg_Dir, Bin_Dir : Unbounded_String := Null_Unbounded_String;
+   end record;
+
+   procedure Create_Log (File_Name : String; Log : Install_Log_Entry) with
+      --  Pre => not Ada.Directories.Exists (File_Name)
+      --  or else raise Invalid_File with "File exists: " & File_Name,
+      Post => Ada.Directories.Exists (File_Name)
+      or else raise Invalid_File with "Unable to create file " & File_Name;
+
+   function Read_Log (File_Name : String) return Install_Log_Entry with
+      Pre => Ada.Directories.Exists (File_Name)
+      or else raise Invalid_File with "File not found: " & File_Name;
+end Logger;

--- a/src/options.adb
+++ b/src/options.adb
@@ -102,7 +102,7 @@ package body Options is
                  or else Check_Argument
                    (Options.Version, "-v", "--version=", Arg, I, Skip)
                  or else Check_Argument
-                   (Options.Tmp_Dir, "-m", "--tmp=", Arg, I, Skip)
+                   (Options.Tmp_Dir, "-t", "--tmp=", Arg, I, Skip)
                  or else Check_Argument
                    (Options.Bin_Dir, "-b", "--bin=", Arg, I, Skip)
                  or else Check_Argument

--- a/src/options.adb
+++ b/src/options.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --
@@ -94,6 +94,8 @@ package body Options is
                if Check_Argument (Options.Show_Help, "-h", "--help", Arg)
                  or else Check_Argument
                    (Options.No_Update_Path, "-p", "--no-path", Arg)
+                 or else Check_Argument
+                    (Options.Show_Version, "-s", "--show-version", Arg)
                  or else Check_Argument
                    (Options.Non_Interactive, "-n", "--non-interactive", Arg)
                  or else Check_Argument (Options.Quiet, "-q", "--quiet", Arg)

--- a/src/options.adb
+++ b/src/options.adb
@@ -91,15 +91,18 @@ package body Options is
             declare
                Arg : constant String := Argument (I);
             begin
-               if Check_Argument
-                   (Options.Show_Help, "-h", "--help", Arg)
+               if Check_Argument (Options.Show_Help, "-h", "--help", Arg)
                  or else Check_Argument
                    (Options.No_Update_Path, "-p", "--no-path", Arg)
                  or else Check_Argument
+                   (Options.Non_Interactive, "-n", "--non-interactive", Arg)
+                 or else Check_Argument (Options.Quiet, "-q", "--quiet", Arg)
+                 or else Check_Argument
+                   (Options.Uninstall, "-u", "--uninstall", Arg)
+                 or else Check_Argument
                    (Options.Version, "-v", "--version=", Arg, I, Skip)
                  or else Check_Argument
-                   (Options.Tmp_Dir, "-m", "--meta=", Arg,
-                    I, Skip)
+                   (Options.Tmp_Dir, "-m", "--tmp=", Arg, I, Skip)
                  or else Check_Argument
                    (Options.Bin_Dir, "-b", "--bin=", Arg, I, Skip)
                  or else Check_Argument
@@ -115,6 +118,7 @@ package body Options is
             Skip := False;
          end if;
       end loop;
+
       return Options;
    end Process_Arguments;
 end Options;

--- a/src/options.ads
+++ b/src/options.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2022-2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --
@@ -26,6 +26,7 @@ package Options is
       Cfg_Dir         : Unbounded_String := Null_Unbounded_String;
       Bin_Dir         : Unbounded_String := Null_Unbounded_String;
       Show_Help       : Boolean          := False;
+      Show_Version    : Boolean          := False;
       Uninstall       : Boolean          := False;
       No_Update_Path  : Boolean          := False;
       Non_Interactive : Boolean          := False;

--- a/src/options.ads
+++ b/src/options.ads
@@ -19,14 +19,17 @@ with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
 package Options is
 
-   --  This will be set if we detect a version
+   --  Our program options
    type Program_Options is record
-      Version        : Unbounded_String := Null_Unbounded_String;
-      Tmp_Dir        : Unbounded_String := Null_Unbounded_String;
-      Cfg_Dir        : Unbounded_String := Null_Unbounded_String;
-      Bin_Dir        : Unbounded_String := Null_Unbounded_String;
-      Show_Help      : Boolean          := False;
-      No_Update_Path : Boolean          := False;
+      Version         : Unbounded_String := Null_Unbounded_String;
+      Tmp_Dir         : Unbounded_String := Null_Unbounded_String;
+      Cfg_Dir         : Unbounded_String := Null_Unbounded_String;
+      Bin_Dir         : Unbounded_String := Null_Unbounded_String;
+      Show_Help       : Boolean          := False;
+      Uninstall       : Boolean          := False;
+      No_Update_Path  : Boolean          := False;
+      Non_Interactive : Boolean          := False;
+      Quiet           : Boolean          := False;
    end record;
 
    --  Exceptions

--- a/src/options.ads
+++ b/src/options.ads
@@ -36,6 +36,7 @@ package Options is
    Invalid_Argument : exception;
    Unknown_Argument : exception;
 
+   --  Processes the arguments based on the command line perams
    function Process_Arguments return Program_Options;
 private
    function Check_Argument

--- a/src/prompts.adb
+++ b/src/prompts.adb
@@ -1,3 +1,20 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Ada.Strings.Fixed;       use Ada.Strings.Fixed;
 with Ada.Text_IO;             use Ada.Text_IO;

--- a/src/prompts.adb
+++ b/src/prompts.adb
@@ -1,0 +1,57 @@
+with Ada.Characters.Handling; use Ada.Characters.Handling;
+with Ada.Strings.Fixed;       use Ada.Strings.Fixed;
+with Ada.Text_IO;             use Ada.Text_IO;
+
+package body Prompts is
+
+   function Get_Answer
+     (Prompt : String; Default_Answer : Yes_or_No := NA) return Yes_or_No
+   is
+      Question : constant String :=
+        Prompt & " [" &
+        (case Default_Answer is when Yes => "Y/n", when No => "y/N",
+           when others                   => "y/n") &
+        "]  >";
+   begin
+      loop
+         Put (Question);
+         declare
+            Response : constant String :=
+              Trim (To_Lower (Get_Line), Ada.Strings.Both);
+         begin
+            if Response'Length = 0 and then Default_Answer /= NA then
+               return Default_Answer;
+            elsif Response = "y" or else Response = "yes" then
+               return Yes;
+            elsif Response = "n" or else Response = "no" then
+               return No;
+            else
+               Put_Line ("Invalid response.");
+            end if;
+         end;
+      end loop;
+   end Get_Answer;
+
+   function Get_Answer
+     (Prompt : String; Default_Answer : String := "") return String
+   is
+      Question : constant String :=
+        Prompt &
+        (if Default_Answer'Length > 0 then " [" & Default_Answer & "]"
+         else "") &
+        " >";
+   begin
+      Put (Question);
+      declare
+         Response : constant String :=
+           Trim (To_Lower (Get_Line), Ada.Strings.Both);
+      begin
+         if Response'Length = 0 and then Default_Answer'Length > 0 then
+            return Default_Answer;
+         else
+            return Response;
+         end if;
+      end;
+   end Get_Answer;
+
+end Prompts;

--- a/src/prompts.adb
+++ b/src/prompts.adb
@@ -5,13 +5,16 @@ with Ada.Text_IO;             use Ada.Text_IO;
 package body Prompts is
 
    function Get_Answer
-     (Prompt : String; Default_Answer : Yes_or_No := NA) return Yes_or_No
+     (Prompt        : String; Default_Answer : Answer := DisableDefault;
+      Provided_Text : String := "") return Answer
    is
       Question : constant String :=
         Prompt & " [" &
         (case Default_Answer is when Yes => "Y/n", when No => "y/N",
            when others                   => "y/n") &
-        "]  >";
+        "] " &
+        (if Provided_Text'Length > 0 then " (" & Provided_Text & ")" else "") &
+        " >";
    begin
       loop
          Put (Question);
@@ -19,7 +22,8 @@ package body Prompts is
             Response : constant String :=
               Trim (To_Lower (Get_Line), Ada.Strings.Both);
          begin
-            if Response'Length = 0 and then Default_Answer /= NA then
+            if Response'Length = 0 and then Default_Answer /= DisableDefault
+            then
                return Default_Answer;
             elsif Response = "y" or else Response = "yes" then
                return Yes;
@@ -33,12 +37,14 @@ package body Prompts is
    end Get_Answer;
 
    function Get_Answer
-     (Prompt : String; Default_Answer : String := "") return String
+     (Prompt        : String; Default_Answer : String := "";
+      Provided_Text : String := "") return String
    is
       Question : constant String :=
         Prompt &
         (if Default_Answer'Length > 0 then " [" & Default_Answer & "]"
          else "") &
+        (if Provided_Text'Length > 0 then " (" & Provided_Text & ")" else "") &
         " >";
    begin
       Put (Question);

--- a/src/prompts.ads
+++ b/src/prompts.ads
@@ -22,10 +22,12 @@ package Prompts is
       Other,  --  "other" - useful for providing 3rd option
       DisableDefault);
 
+   --  Prompts a yes or no question, with optional default.
    function Get_Answer
      (Prompt        : String; Default_Answer : Answer := DisableDefault;
       Provided_Text : String := "") return Answer;
 
+   --  Prompts a question and accepts a string, with optional default answer.
    function Get_Answer
      (Prompt        : String; Default_Answer : String := "";
       Provided_Text : String := "") return String;

--- a/src/prompts.ads
+++ b/src/prompts.ads
@@ -1,9 +1,15 @@
 package Prompts is
-   type Yes_or_No is (No, Yes, NA);
+   type Answer is
+     (No, --  Answer is "No"
+      Yes, --  Answer is "Yes"
+      Other,  --  "other" - useful for providing 3rd option
+      DisableDefault);
 
    function Get_Answer
-     (Prompt : String; Default_Answer : Yes_or_No := NA) return Yes_or_No;
+     (Prompt        : String; Default_Answer : Answer := DisableDefault;
+      Provided_Text : String := "") return Answer;
 
    function Get_Answer
-     (Prompt : String; Default_Answer : String := "") return String;
+     (Prompt        : String; Default_Answer : String := "";
+      Provided_Text : String := "") return String;
 end Prompts;

--- a/src/prompts.ads
+++ b/src/prompts.ads
@@ -1,0 +1,9 @@
+package Prompts is
+   type Yes_or_No is (No, Yes, NA);
+
+   function Get_Answer
+     (Prompt : String; Default_Answer : Yes_or_No := NA) return Yes_or_No;
+
+   function Get_Answer
+     (Prompt : String; Default_Answer : String := "") return String;
+end Prompts;

--- a/src/settings.adb
+++ b/src/settings.adb
@@ -1,0 +1,94 @@
+with Ada.Environment_Variables;
+with Ada.Directories;
+with Defaults;
+package body Settings is
+
+   function Correct_Path (Home_Dir : String; Path : String) return String is
+      Corrected_Path : constant String :=
+        (if Path (Path'First) = '~' then
+           Home_Dir & "/" &
+           (if Path'Length > 1 then Path (Path'First + 1 .. Path'Last) else "")
+         else Path);
+   begin
+      return Ada.Directories.Full_Name (Corrected_Path);
+   end Correct_Path;
+
+   function Init_Settings (Options : Program_Options) return Program_Settings
+   is
+      Current_Platform : constant Platform := Local_Settings.Init_Platform;
+
+      --  On windows it's "HOMEPATH", but unix is "HOME".
+      Home_Env : constant String :=
+        (case Current_Platform.OS is when Windows => "HOMEPATH",
+           when others                            => "HOME");
+
+      Home_Dir : constant String :=
+        (if Ada.Environment_Variables.Exists (Home_Env) then
+           Ada.Environment_Variables.Value (Home_Env)
+         else raise No_Environment_Variable
+             with "Cannot find the $HOME environment variable. " &
+             "No home directory can be found.");
+
+      Version : constant String :=
+        (if Options.Version /= Null_Unbounded_String then
+           To_String (Options.Version)
+         elsif Ada.Environment_Variables.Exists (Defaults.Ver_Env) then
+           Ada.Environment_Variables.Value (Defaults.Ver_Env)
+         else "");
+
+      Tmp_Dir : constant String :=
+        Correct_Path
+          (Home_Dir,
+           (if Options.Tmp_Dir /= Null_Unbounded_String then
+              To_String (Options.Tmp_Dir)
+            else
+              (if Ada.Environment_Variables.Exists (Defaults.Tmp_Env) then
+                 Ada.Environment_Variables.Value (Defaults.Tmp_Env)
+               else Home_Dir & Defaults.Tmp_Dir)));
+
+      --  TODO: Need to decide on a location...
+      --  since alire uses ~/.config/alire for everything maybe
+      --  we have ~/.config/getada/env.sh instead of ~/.getada/env.sh ?
+      Cfg_Dir : constant String :=
+        Correct_Path
+          (Home_Dir,
+           (if Options.Cfg_Dir /= Null_Unbounded_String then
+              To_String (Options.Cfg_Dir)
+            else
+              (if Ada.Environment_Variables.Exists (Defaults.Cfg_Env) then
+                 Ada.Environment_Variables.Value (Defaults.Cfg_Env)
+               else Home_Dir & Defaults.Cfg_Dir)));
+      --  TODO: Put this in Program Files on Windows +
+      --       and Home_Dir/Applications/bin on MacOS?
+      --       do something like:
+      --       Local_Apps: constant String := Local_Settings.App_Dir;
+      Bin_Dir : constant String :=
+        Correct_Path
+          (Home_Dir,
+           (if Options.Bin_Dir /= Null_Unbounded_String then
+              To_String (Options.Bin_Dir)
+            else
+              (if Ada.Environment_Variables.Exists (Defaults.Bin_Env) then
+                 Ada.Environment_Variables.Value (Defaults.Bin_Env)
+               else Cfg_Dir & Defaults.Bin_Dir)));
+
+      Path_Env : constant String :=
+        (if Ada.Environment_Variables.Exists ("PATH") then
+           Ada.Environment_Variables.Value ("PATH")
+         else "");
+
+      Our_Settings : constant Program_Settings :=
+        (Current_Platform => Current_Platform,
+         Version          => To_Unbounded_String (Version),
+         Tmp_Dir          => To_Unbounded_String (Tmp_Dir),
+         Cfg_Dir          => To_Unbounded_String (Cfg_Dir),
+         Bin_Dir          => To_Unbounded_String (Bin_Dir),
+         Home_Dir         => To_Unbounded_String (Home_Dir),
+         Path_Env         => To_Unbounded_String (Path_Env),
+         No_Update_Path   => Options.No_Update_Path,
+         Non_Interactive  => Options.Non_Interactive, Quiet => Options.Quiet);
+   begin
+      return Our_Settings;
+   end Init_Settings;
+
+end Settings;

--- a/src/settings.adb
+++ b/src/settings.adb
@@ -1,3 +1,20 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 with Ada.Environment_Variables;
 with Ada.Directories;
 with Defaults;

--- a/src/settings.ads
+++ b/src/settings.ads
@@ -1,3 +1,20 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Options;               use Options;
 with Local_Settings;        use Local_Settings;

--- a/src/settings.ads
+++ b/src/settings.ads
@@ -1,0 +1,27 @@
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Options;               use Options;
+with Local_Settings;        use Local_Settings;
+package Settings is
+
+   No_Environment_Variable : exception;
+
+   type Program_Settings is record
+      Current_Platform : Platform;
+      Version          : Unbounded_String;
+      Tmp_Dir          : Unbounded_String;
+      Cfg_Dir          : Unbounded_String;
+      Bin_Dir          : Unbounded_String;
+      Home_Dir         : Unbounded_String;
+      Path_Env         : Unbounded_String;
+      No_Update_Path   : Boolean;
+      Non_Interactive  : Boolean;
+      Quiet            : Boolean;
+   end record;
+
+   --  Takes program options and initalizes the settings we'll install.
+   function Init_Settings (Options : Program_Options) return Program_Settings;
+
+private
+   function Correct_Path (Home_Dir : String; Path : String) return String;
+
+end Settings;

--- a/src/shells.ads
+++ b/src/shells.ads
@@ -41,7 +41,6 @@ package Shells is
      (Shell_Name : Supported_Shells; File : File_Type; Dir : String);
    function Get_Env_Command
      (Shell_Name : Supported_Shells; Env_File : String) return String;
-
 private
    --  Gets the config file for each shell.
    function Get_Shell_Config (Shell_Name : Supported_Shells) return String;

--- a/src/shells.ads
+++ b/src/shells.ads
@@ -23,22 +23,33 @@ with Ada.Text_IO;           use Ada.Text_IO;
 package Shells is
    No_Shells_Found   : exception;
    Unsupported_Shell : exception;
+
    --  Set the supported shells here.
    type Supported_Shells is
      (null_shell,
       sh,
       bash, --  bash will use sh's .profile
       zsh);
+
    --  This is for returning a list of path files.
    type Shell_Config is record
       Config_File : Unbounded_String;
       Shell       : Supported_Shells;
    end record;
+
    type Shell_Array is array (Positive range <>) of Shell_Config;
+
+   --  Returns the shells available for a given platform.
    function Available_Shells (Current_Platform : Platform) return Shell_Array;
+
+   --  Returns the env file for that shell. For example, .profile for sh.
    function Get_Shell_Env (Shell_Name : Supported_Shells) return String;
+
+   --  Writes the getada script to a file based on shell type.
    procedure Write_Env_File
      (Shell_Name : Supported_Shells; File : File_Type; Dir : String);
+
+   --  Gets the command to run the env file. E.g. ". <Env_File>" for sh.
    function Get_Env_Command
      (Shell_Name : Supported_Shells; Env_File : String) return String;
 private

--- a/src/shells.ads
+++ b/src/shells.ads
@@ -19,9 +19,9 @@ pragma Assertion_Policy (Check);
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Local_Settings;        use Local_Settings;
 with Ada.Text_IO;           use Ada.Text_IO;
-with Ada.Directories;
+
 package Shells is
-   No_Shell_File     : exception;
+   No_Shells_Found   : exception;
    Unsupported_Shell : exception;
    --  Set the supported shells here.
    type Supported_Shells is
@@ -35,11 +35,7 @@ package Shells is
       Shell       : Supported_Shells;
    end record;
    type Shell_Array is array (Positive range <>) of Shell_Config;
-   function Available_Shells
-     (Current_Platform : Platform) return Shell_Array with
-      Pre => Ada.Directories.Exists ("/etc/shells")
-      or else raise No_Shell_File
-        with "Cannot locate /etc/shells. Please pass ""--no-path""";
+   function Available_Shells (Current_Platform : Platform) return Shell_Array;
    function Get_Shell_Env (Shell_Name : Supported_Shells) return String;
    procedure Write_Env_File
      (Shell_Name : Supported_Shells; File : File_Type; Dir : String);

--- a/src/uninstaller.adb
+++ b/src/uninstaller.adb
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/uninstaller.adb
+++ b/src/uninstaller.adb
@@ -1,0 +1,214 @@
+--    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--
+--    This file is part of GetAda: the Unofficial Alire Installer
+--
+--    This program is free software: you can redistribute it and/or modify
+--    it under the terms of the GNU General Public License as published by
+--    the Free Software Foundation, either version 3 of the License, or
+--    (at your option) any later version.
+--
+--    This program is distributed in the hope that it will be useful,
+--    but WITHOUT ANY WARRANTY; without even the implied warranty of
+--    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+--    GNU General Public License for more details.
+--
+--    You should have received a copy of the GNU General Public License
+--    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+with Ada.Directories;
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Ada.Strings.Fixed;     use Ada.Strings.Fixed;
+with Ada.Text_IO;           use Ada.Text_IO;
+with Ada.IO_Exceptions;
+
+with Console_IO; use Console_IO;
+with Files;      use Files;
+with Prompts;    use Prompts;
+with Defaults;
+
+package body Uninstaller is
+
+   procedure Process_Uninstall
+     (Log     : Install_Log; Our_Settings : Program_Settings;
+      Pretend : Boolean := False)
+   is
+      IO           : constant C_IO             := Init (Our_Settings);
+      Old_Settings : constant Program_Settings := Log.Get_Settings;
+
+      --  Removes the env file entry from config files.
+      procedure Remove_Env_Files (Data : String; Pretend : Boolean := False) is
+         SubStr    : Natural := Data'First;
+         Entry_Sep : Natural;
+      begin
+         --  Read up to the next '@' or end of string.
+         loop
+            Entry_Sep := Index (Data (SubStr .. Data'Last), Entry_Seperator);
+            declare
+               Our_Line : constant String :=
+                 Data
+                   (SubStr ..
+                        (if Entry_Sep > 0 then Entry_Sep - 1 else Data'Last));
+               --  Split by '%' (it MUST contain a '%')
+               Item_Sep : constant Natural := Index (Our_Line, Item_Seperator);
+               File     : constant String  :=
+                 Our_Line
+                   (Our_Line'First ..
+                        (if Item_Sep > 0 then Item_Sep - 1
+                         else raise Invalid_Log
+                             with "Log entry missing item seperator"));
+               Command : constant String :=
+                 Our_Line (Item_Sep + 1 .. Our_Line'Last);
+            begin
+               --  Go through the command, removing the file.
+               if Line_Exists (File, Command) then
+                  declare
+                     Tmp_Name : constant String := File & ".tmp"; --  Temp file
+                     Orig     : File_Type; --  to load original file
+                     Temp     : File_Type; --  to load temporary file
+                  begin
+                     if Pretend then
+                        IO.Must_Say
+                          ("Remove line `" & Command & "` from: " & File);
+                     else
+                        IO.Say_Line
+                          ("Removing line `" & Command & "` from: " & File);
+                        Open (Orig, In_File, File);
+                        Create (Temp, Out_File, Tmp_Name);
+                        while not End_Of_File (Orig) loop
+                           declare
+                              Next_Line : constant String := Get_Line (Orig);
+                           begin
+                              --  Only write the line if it isn't the command.
+                              if Next_Line /= Command then
+                                 Put_Line (Temp, Next_Line);
+                              end if;
+                           end;
+                        end loop;
+                        Close (Orig);
+                        Close (Temp);
+                        --  Move the temp file over the original
+                        Ada.Directories.Delete_File (File);
+                        Ada.Directories.Rename (Tmp_Name, File);
+                     end if;
+                  end;
+               end if;
+               exit when Entry_Sep = 0; --  This is the last entry
+               SubStr := Entry_Sep + 1; --  Move to next entry if not.
+            end;
+         end loop;
+      end Remove_Env_Files;
+
+      --  Removes a file (if it exists) is
+      procedure Remove_File (Data : String; Pretend : Boolean := False) is
+      begin
+         if Ada.Directories.Exists (Data) then
+            if Pretend then
+               IO.Must_Say ("Remove: " & Data);
+            else
+               IO.Say_Line ("Removing: " & Data);
+               Ada.Directories.Delete_File (Data);
+            end if;
+         end if;
+      exception
+         when Ada.IO_Exceptions.Use_Error =>
+            Put_Line (Standard_Error, "Unable to remove file: " & Data);
+            Put_Line (Standard_Error, "Reason: In Use.");
+         when others =>
+            Put_Line (Standard_Error, "Unable to remove file: " & Data);
+            Put_Line (Standard_Error, "Other error detected.");
+      end Remove_File;
+
+      --  Removes a directory (if it exists) is
+      procedure Remove_Dir (Data : String; Pretend : Boolean := False) is
+      begin
+         if Ada.Directories.Exists (Data) then
+            if Pretend then
+               IO.Must_Say ("Remove: " & Data);
+            else
+               IO.Say_Line ("Removing: " & Data);
+               Ada.Directories.Delete_Directory (Data);
+            end if;
+         end if;
+      exception
+         when Ada.IO_Exceptions.Use_Error =>
+            Put_Line (Standard_Error, "Unable to remove directory: " & Data);
+            Put_Line (Standard_Error, "Reason: In Use");
+         when others =>
+            Put_Line (Standard_Error, "Unable to remove file: " & Data);
+            Put_Line (Standard_Error, "Other error detected.");
+      end Remove_Dir;
+
+   begin
+      --  Show what will happen when uninstalled.
+      if Pretend then
+         IO.Must_Say
+           ("The following will be preformed to uninstall Alire and Getada:");
+      end if;
+      for S in reverse Stage'Range loop
+         --  Check if work was done on this entry (ignore NA/Failed)
+         if Log.Get_Status (S) = Success then
+            case S is
+               when Added_Env_File =>
+                  --  Remove the env file command from files.
+                  Remove_Env_Files (Log.Get_Data (S), Pretend);
+               when Created_Env_File =>
+                  --  Remove the env file itself
+                  Remove_File (Log.Get_Data (S), Pretend);
+               when Extracted =>
+                  --  Remove the extracted binary file
+                  Remove_File (Log.Get_Data (S), Pretend);
+               when Downloaded =>
+                  --  Remove the downloaded file
+                  Remove_File (Log.Get_Data (S), Pretend);
+               when others =>
+                  null;
+            end case;
+         end if;
+      end loop;
+      --  Remove metadata, bin dir, log, and config directory.
+      Remove_Dir (To_String (Old_Settings.Tmp_Dir), Pretend);
+      Remove_Dir (To_String (Old_Settings.Bin_Dir), Pretend);
+      Remove_File
+        (To_String (Old_Settings.Cfg_Dir & Defaults.Log_File), Pretend);
+      Remove_Dir (To_String (Old_Settings.Cfg_Dir), Pretend);
+   end Process_Uninstall;
+
+   --  Uninstaller utilizing log and program settings. Prompts user if needed.
+   procedure Uninstall
+     (Log          : Install_Log; Our_Settings : Program_Settings;
+      Never_Prompt : Boolean := False)
+   is
+   begin
+      --  If we haven't specified never to prompt and are interactive:
+      if not Never_Prompt and then not Our_Settings.Non_Interactive then
+         --  Print what the uninstaller will do based on the log.
+         Process_Uninstall (Log, Our_Settings, Pretend => True);
+         if Get_Answer ("Do you wish to continue?", Default_Answer => No) = No
+         then --  Thanks to Donna!  No longer a case statement.
+            raise User_Aborted;
+         end if;
+      end if;
+      Process_Uninstall (Log, Our_Settings);
+
+   end Uninstall;
+
+   --  General uninstaller just utilizing program settings.
+   procedure Uninstall (Our_Settings : Program_Settings) is
+      Log_File : constant String :=
+        To_String (Our_Settings.Cfg_Dir) & Defaults.Log_File;
+   begin
+      declare
+         Log : constant Install_Log := Load (Log_File);
+      begin
+         Uninstall (Log, Our_Settings);
+      end;
+   exception
+      when Invalid_File =>
+         Put_Line ("crap");
+         raise No_Log_Found
+           with """" & Log_File & "..." & Defaults.NL &
+           "If alire is installed with Getada then please pass:" &
+           " --cfg=/directory" & Defaults.NL &
+           "where ""/directory"" contains a log.dat file.";
+   end Uninstall;
+end Uninstaller;

--- a/src/uninstaller.ads
+++ b/src/uninstaller.ads
@@ -1,4 +1,4 @@
---    Copyright (C) 2022 A.J. Ianozi <aj@ianozi.com>
+--    Copyright (C) 2023 A.J. Ianozi <aj@ianozi.com>
 --
 --    This file is part of GetAda: the Unofficial Alire Installer
 --

--- a/src/uninstaller.ads
+++ b/src/uninstaller.ads
@@ -15,18 +15,23 @@
 --    You should have received a copy of the GNU General Public License
 --    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package Prompts is
-   type Answer is
-     (No, --  Answer is "No"
-      Yes, --  Answer is "Yes"
-      Other,  --  "other" - useful for providing 3rd option
-      DisableDefault);
+pragma Assertion_Policy (Check);
+with Settings; use Settings;
+with Logger;   use Logger;
+package Uninstaller is
+   No_Log_Found : exception;
+   Invalid_Log  : exception;
+   User_Aborted : exception;
+   --  Starts uninstaller for getada+alire based on provided settings.
+   procedure Uninstall (Our_Settings : Program_Settings);
 
-   function Get_Answer
-     (Prompt        : String; Default_Answer : Answer := DisableDefault;
-      Provided_Text : String := "") return Answer;
-
-   function Get_Answer
-     (Prompt        : String; Default_Answer : String := "";
-      Provided_Text : String := "") return String;
-end Prompts;
+   --  Starts uninstaller for getada+alire, potentially with prompts.
+   procedure Uninstall
+     (Log          : Install_Log; Our_Settings : Program_Settings;
+      Never_Prompt : Boolean := False);
+private
+   --  Uninstalls getada+alire.
+   procedure Process_Uninstall
+     (Log     : Install_Log; Our_Settings : Program_Settings;
+      Pretend : Boolean := False);
+end Uninstaller;


### PR DESCRIPTION
Version has been updated to 0.2.0-dev, which brings the ability to uninstall GetAda.  A log must be available for this to be successful, so if GetAda was used to install previously it won't work.  This will need more testing besides just me though!